### PR TITLE
Capitalized class autoremote to avoid namespace collision with module

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Credits:
 
 Install:
 
-sudo pip -install git+https://github.com/ddyeakley/autoremote.git
+sudo pip install git+https://github.com/ddyeakley/autoremote.git
 
 General API usage:
 

--- a/autoremote/autoremote.py
+++ b/autoremote/autoremote.py
@@ -4,7 +4,7 @@ import requests
 import argparse
 
 
-class autoremote:
+class Autoremote:
     def __init__(self, url=None):
         self.key_url = requests.get(url, allow_redirects=True)
         if self.key_url.status_code == 200:
@@ -69,7 +69,7 @@ if __name__ == "__main__":
 
     # noinspection PyBroadException
     try:
-        ar = autoremote(url=_url)   # Connect to AutoRemote server
+        ar = Autoremote(url=_url)   # Connect to AutoRemote server
         if _name:
             # noinspection PyBroadException
             try:


### PR DESCRIPTION
I was having some weird import issues, and this seemed to fix it. Plus it's more pythonic. Sorry if this is pedantic!